### PR TITLE
fix: change string quotes

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ from ui.about import Ui_dialog_about
 
 SEARCH_TYPES = ["contains", "does not contain", "regex"]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 
 class TerraformValidateExplorer(QMainWindow):

--- a/parser.py
+++ b/parser.py
@@ -41,10 +41,10 @@ def get_initial_data(data: dict) -> dict[str, List[str]]:
 
     assert len(warnings) == data.get(
         "warning_count"
-    ), f"Number of parsed warnings, {len(warnings)}, should be the same as the number of warnings in the file, which is {data.get("warning_count")}"
+    ), f"Number of parsed warnings, {len(warnings)}, should be the same as the number of warnings in the file, which is {data.get('warning_count')}"
     assert len(errors) == data.get(
         "error_count"
-    ), f"Number of parsed errors, {len(errors)}, should be the same as the number of errors in the file, which is {data.get("error_count")}"
+    ), f"Number of parsed errors, {len(errors)}, should be the same as the number of errors in the file, which is {data.get('error_count')}"
 
     return {
         "errors": errors,


### PR DESCRIPTION
# Descriptions
-  I tested run the app from GitHub on Linux and Mac.
-  I found a string issue in the parser file and fixed it.
# Details
- Removed "" and replaced it with ''.
# Fix
### To reproduce the fix:
```bash
python3 --version
# Python 3.9.0
python3 -m venv ./venv
source ./venv/bin/activate
pip install -r requirements.txt
python main.py
```
Then, this error appears:
![image](https://github.com/user-attachments/assets/82b3284e-833c-4e5a-8324-0dbe0c408c3c)

# Test/QA
After fixing the issue, the app ran successfully.

![Captura desde 2025-01-31 13-29-35](https://github.com/user-attachments/assets/f13df2ae-f40a-478d-8329-b661ab6d39eb)


# Deploy
- No changes