### PR TITLE
fix: input elements are changed from disabled to enabled when a file is opened

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ from ui.about import Ui_dialog_about
 
 SEARCH_TYPES = ["contains", "does not contain", "regex"]
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 
 class TerraformValidateExplorer(QMainWindow):
@@ -68,6 +68,12 @@ class TerraformValidateExplorer(QMainWindow):
     def _show_about(self):
         dlg = AboutDialog()
         dlg.exec()
+
+    def _enable_inputs(self):
+        self.ui.action_reload.setEnabled(True)
+        self.ui.line_filter.setEnabled(True)
+        self.ui.combo_search_type.setEnabled(True)
+        self.ui.check_unique.setEnabled(True)
 
     def get_file_contents(self):
         # if a file path is not set, open the file; if it is set, just reload
@@ -192,7 +198,7 @@ class TerraformValidateExplorer(QMainWindow):
         )
 
         self.file_path = file_path
-        self.ui.action_reload.setEnabled(True)
+        self._enable_inputs()
 
         return file_path
 

--- a/ui/ui.py
+++ b/ui/ui.py
@@ -58,17 +58,20 @@ class Ui_MainWindow(object):
         self.horizontalLayout.setObjectName(u"horizontalLayout")
         self.line_filter = QLineEdit(self.centralwidget)
         self.line_filter.setObjectName(u"line_filter")
+        self.line_filter.setEnabled(False)
         self.line_filter.setMaxLength(255)
 
         self.horizontalLayout.addWidget(self.line_filter)
 
         self.combo_search_type = QComboBox(self.centralwidget)
         self.combo_search_type.setObjectName(u"combo_search_type")
+        self.combo_search_type.setEnabled(False)
 
         self.horizontalLayout.addWidget(self.combo_search_type)
 
         self.check_unique = QCheckBox(self.centralwidget)
         self.check_unique.setObjectName(u"check_unique")
+        self.check_unique.setEnabled(False)
 
         self.horizontalLayout.addWidget(self.check_unique)
 

--- a/ui/ui.ui
+++ b/ui/ui.ui
@@ -27,6 +27,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLineEdit" name="line_filter">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="maxLength">
            <number>255</number>
           </property>
@@ -36,10 +39,17 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="combo_search_type"/>
+         <widget class="QComboBox" name="combo_search_type">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="check_unique">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text">
            <string>Only unique</string>
           </property>


### PR DESCRIPTION
input elements, such as the line edit, are initially disabled. opening a file enables them.

closes #3

## Testing

Initial UI state - inputs are disabled

<img width="833" alt="Screenshot 2025-02-01 at 12 30 43" src="https://github.com/user-attachments/assets/8d52840e-eb69-429f-ac1c-c523a8aac8ce" />

UI after opening a file - inputs are enabled

<img width="833" alt="Screenshot 2025-02-01 at 12 30 58" src="https://github.com/user-attachments/assets/282b67d0-f09f-4baf-9cb0-ac9b1fd9f006" />